### PR TITLE
Build and fix cloudinary env error

### DIFF
--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,11 +1,23 @@
 import { v2 as cloudinary } from 'cloudinary';
 
-// Configure Cloudinary
+// Configure Cloudinary using Next.js environment variables
+const {
+  NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+  NEXT_PUBLIC_CLOUDINARY_API_KEY,
+  NEXT_PUBLIC_CLOUDINARY_API_SECRET,
+} = process.env;
+
+if (!NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME || !NEXT_PUBLIC_CLOUDINARY_API_KEY || !NEXT_PUBLIC_CLOUDINARY_API_SECRET) {
+  throw new Error(
+    'Missing Cloudinary environment variables. Please set NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME, NEXT_PUBLIC_CLOUDINARY_API_KEY and NEXT_PUBLIC_CLOUDINARY_API_SECRET in your environment.'
+  );
+}
+
 cloudinary.config({
-  cloud_name: import.meta.env.VITE_CLOUDINARY_CLOUD_NAME,
-  api_key: import.meta.env.VITE_CLOUDINARY_API_KEY,
-  api_secret: import.meta.env.VITE_CLOUDINARY_API_SECRET,
-  secure: true
+  cloud_name: NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
+  api_key: NEXT_PUBLIC_CLOUDINARY_API_KEY,
+  api_secret: NEXT_PUBLIC_CLOUDINARY_API_SECRET,
+  secure: true,
 });
 
 export default cloudinary;


### PR DESCRIPTION
Update Cloudinary environment variable access to use Next.js `process.env` and add validation.

The previous `import.meta.env` syntax is specific to Vite and caused build failures in the Next.js environment. This change ensures correct environment variable loading and provides early error detection if variables are missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0d128b9-fb46-4062-8c67-7fdbd23e1ef6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0d128b9-fb46-4062-8c67-7fdbd23e1ef6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>